### PR TITLE
Revert changes from f6160765b786a81dfbd48d42cda88580ad65d071

### DIFF
--- a/src/game/client/c_baseanimating.h
+++ b/src/game/client/c_baseanimating.h
@@ -75,17 +75,11 @@ struct RagdollInfo_t
 class CAttachmentData
 {
 public:
-	CAttachmentData()
-	{
-		m_nLastFramecount = 31;
-		m_bAnglesComputed = 1;
-	}
-
 	matrix3x4_t	m_AttachmentToWorld;
 	QAngle	m_angRotation;
 	Vector	m_vOriginVelocity;
-	int		m_nLastFramecount;
-	int		m_bAnglesComputed;
+	int		m_nLastFramecount : 31;
+	int		m_bAnglesComputed : 1;
 };
 
 


### PR DESCRIPTION
The two ints are supposed to have 32 bits of data total 31 for framecount, 1 for "boolean"
Also the constructor was setting bogus values
I'm not sure if it is really important that the struct is 80 bytes instead of 76 bytes